### PR TITLE
Add vitest and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -24,6 +25,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.1"
   }
 }

--- a/src/services/__tests__/voteService.test.js
+++ b/src/services/__tests__/voteService.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getItemTypeNameFromId } from '../voteService.js';
+
+describe('getItemTypeNameFromId', () => {
+  it('returns DB Product for type id 1', () => {
+    expect(getItemTypeNameFromId(1)).toBe('DB Product');
+  });
+
+  it('returns DB Ticket for type id 2', () => {
+    expect(getItemTypeNameFromId(2)).toBe('DB Ticket');
+  });
+
+  it('returns Deal for type id 3', () => {
+    expect(getItemTypeNameFromId(3)).toBe('Deal');
+  });
+
+  it('returns Viator Ticket for type id 4', () => {
+    expect(getItemTypeNameFromId(4)).toBe('Viator Ticket');
+  });
+
+  it('returns null for unknown type ids', () => {
+    expect(getItemTypeNameFromId(999)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `vitest` to dev deps
- set up a `test` npm script
- test voteService `getItemTypeNameFromId`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0255d76c832390a371244a3cfd48