### PR TITLE
Fix OAuthCallback header comment

### DIFF
--- a/src/auth/OAuthCallback.jsx
+++ b/src/auth/OAuthCallback.jsx
@@ -1,9 +1,10 @@
-// src/auth/OAuth2Callback.jsx
+// src/auth/OAuthCallback.jsx
+
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./AuthContext";
 
-export default function OAuth2Callback() {
+export default function OAuthCallback() {
   const navigate = useNavigate();
   const { fetchUser } = useAuth(); // expose a fetchUser helper
 


### PR DESCRIPTION
## Summary
- add a blank line after the header comment in `OAuthCallback.jsx`
- verified that no outdated references remain in the file

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e0255703c8323b4f784d76ac93dc9