### PR TITLE
Fix default channel logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      window.DEFAULT_CHANNEL_ID = "3d8c4c38-2d6e-483c-bdc5-e1eeeadd155e";
+    </script>
     <script type="module" src="/src/main.jsx"></script>
     <script src="/screen.js"></script>
   </body>

--- a/public/screen.js
+++ b/public/screen.js
@@ -1,10 +1,9 @@
 // Inject channelId into window for any non-React scripts
 (function () {
+  const DEFAULT_CHANNEL_ID =
+    window.DEFAULT_CHANNEL_ID || "3d8c4c38-2d6e-483c-bdc5-e1eeeadd155e";
   const params = new URLSearchParams(window.location.search);
-  let channelId =
-    params.get("channelId") ||
-    localStorage.getItem("channelId") ||
-    "3d8c4c38-2d6e-483c-bdc5-e1eeeadd155e";
+  let channelId = params.get("channelId") || DEFAULT_CHANNEL_ID;
   try {
     localStorage.setItem("channelId", channelId);
   } catch {}

--- a/src/hooks/useChannelId.js
+++ b/src/hooks/useChannelId.js
@@ -1,15 +1,13 @@
 // src/hooks/useChannelId.js
 import { useMemo } from "react";
 
-const DEFAULT_CHANNEL_ID = "3d8c4c38-2d6e-483c-bdc5-e1eeeadd155e";
+export const DEFAULT_CHANNEL_ID =
+  window.DEFAULT_CHANNEL_ID || "3d8c4c38-2d6e-483c-bdc5-e1eeeadd155e";
 
 export function useChannelId() {
   return useMemo(() => {
     const params = new URLSearchParams(window.location.search);
-    let id =
-      params.get("channelId") ||
-      localStorage.getItem("channelId") ||
-      DEFAULT_CHANNEL_ID;
+    let id = params.get("channelId") || DEFAULT_CHANNEL_ID;
 
     // always store the final value
     try {


### PR DESCRIPTION
## Summary
- configure `DEFAULT_CHANNEL_ID` globally in `index.html`
- use the global constant in `useChannelId` and `screen.js`
- ignore `localStorage` when determining initial channel id

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e126b2a348323b39f7980fd43d026