### PR TITLE
Fix ReferenceError for edgeConsole

### DIFF
--- a/src/legacy/modules/products.js
+++ b/src/legacy/modules/products.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { UpdateProductViaDataRole } from "../screen";
 export let products = [];
 export let productDataQueue = [];
 export let productsPaused = false;

--- a/src/legacy/screen.js
+++ b/src/legacy/screen.js
@@ -36,6 +36,16 @@ const REMOVE_VOTE_URL = `${VOTE_TRACKING_BASE_URL}/vote`;
 
 let votedProducts = []; // Stores products fetched from /votes/products
 
+// Basic wrapper around the standard console so legacy code can log
+// without relying on a global provided elsewhere. This mirrors the
+// definition used in the standalone public script.
+let edgeConsole = {
+  log: (...args) => window.console.log(...args),
+  info: (...args) => window.console.info(...args),
+  error: (...args) => window.console.error(...args),
+  // add warn, debug, etc. as needed
+};
+
 
 
 /**
@@ -761,6 +771,9 @@ function UpdateProductViaDataRole(i, time = null) {
   }
 }
 
+// Expose for other modules that rely on a global function
+window.UpdateProductViaDataRole = UpdateProductViaDataRole;
+
 /**
  * Updates the visual style of ALL like/dislike buttons on the page
  * matching a specific product ID.
@@ -1373,4 +1386,6 @@ function initializeApp() {
 export function startScreen() {
   initializeApp();
 }
+
+export { UpdateProductViaDataRole };
 


### PR DESCRIPTION
## Summary
- ensure `edgeConsole` exists in legacy screen module
- expose `UpdateProductViaDataRole` globally so product queue can call it

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e2e67c51c832398b9f85f30283256