### PR TITLE
Refactor API base URLs

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,0 +1,2 @@
+export const BACKEND_BASE_URL = "https://fastapi.edgevideo.ai";
+export const VOTE_TRACKING_BASE_URL = `${BACKEND_BASE_URL}/tracking`;

--- a/src/legacy/screen.js
+++ b/src/legacy/screen.js
@@ -12,6 +12,7 @@ import {
   FormatTicketDateTime,
   FormatPrice,
 } from "./modules/products";
+import { BACKEND_BASE_URL, VOTE_TRACKING_BASE_URL } from "../config/api";
 // Inject channelId into window for any non-React scripts
 (function () {
   const DEFAULT_CHANNEL_ID =
@@ -27,7 +28,6 @@ import {
 const wsUrl = "wss://slave-ws-service-342233178764.us-west1.run.app"; // WebSocket server URL
 
 // Add these near other configuration variables
-const VOTE_TRACKING_BASE_URL = "https://fastapi.edgevideo.ai/tracking";
 const UPVOTE_URL = `${VOTE_TRACKING_BASE_URL}/vote/up`;
 const DOWNVOTE_URL = `${VOTE_TRACKING_BASE_URL}/vote/down`;
 const VOTED_PRODUCTS_URL = `${VOTE_TRACKING_BASE_URL}/votes/products`;
@@ -212,7 +212,7 @@ function SetShoppingAIStatus(messageText) {
 async function getCachedProducts() {
   if (typeof channelId !== "undefined" && channelId !== null) {
     let cachedProductResponse = await fetch(
-      `https://fastapi.edgevideo.ai/product_search/recent_products/${channelId}/4`
+      `${BACKEND_BASE_URL}/product_search/recent_products/${channelId}/4`
     );
     let cachedProductData = await cachedProductResponse.json();
     for (let cachedProduct of cachedProductData)
@@ -439,7 +439,7 @@ async function trackClick(productData) {
 
     try {
       const response = await fetch(
-        "https://fastapi.edgevideo.ai/tracking/click",
+        `${VOTE_TRACKING_BASE_URL}/click`,
         {
           method: "POST",
           headers: {
@@ -1141,8 +1141,7 @@ function populateFavoritesTab() {
 // This bit handles logging in
 function setupLoginHandling() {
   // --- Configuration ---
-  const backendBaseUrl = "https://fastapi.edgevideo.ai";
-  const authRouteBase = `${backendBaseUrl}/auth_google`;
+  const authRouteBase = `${BACKEND_BASE_URL}/auth_google`;
   const userInfoUrl = `${authRouteBase}/details`; // URL to get user details
   const frontendUrl = window.location.origin + window.location.pathname; // URL for redirect
 

--- a/src/services/voteService.js
+++ b/src/services/voteService.js
@@ -1,7 +1,7 @@
 // src/services/voteService.js
-const BASE = "https://fastapi.edgevideo.ai/tracking";
-const UPVOTE_URL = `${BASE}/vote/up`;
-const DOWNVOTE_URL = `${BASE}/vote/down`;
+import { VOTE_TRACKING_BASE_URL } from "../config/api";
+const UPVOTE_URL = `${VOTE_TRACKING_BASE_URL}/vote/up`;
+const DOWNVOTE_URL = `${VOTE_TRACKING_BASE_URL}/vote/down`;
 
 function normalizeItemTypeName(name) {
   if (!name) return "DB Product";


### PR DESCRIPTION
## Summary
- centralize API base URLs in a new `src/config/api.js`
- use shared constants in `voteService.js`
- use shared constants in `legacy/screen.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684ea57636608323b5a5e085cd60c686