### PR TITLE
Display product details in cards for hover devices

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ import BuildInfo from "./components/BuildInfo";
 import OAuthCallback from "./auth/OAuthCallback";
 
 export default function App() {
-  const { isOpen: sidebarOpen, openSidebar, closeSidebar } = useSidebar();
+  const { isOpen: sidebarOpen, closeSidebar } = useSidebar();
   const { pathname } = useLocation();
 
   // Only show the profile sidebar on /app routes

--- a/src/components/BuildInfo.jsx
+++ b/src/components/BuildInfo.jsx
@@ -1,5 +1,6 @@
 // src/components/BuildInfo.jsx
 import React from "react";
+/* global __COMMIT_HASH__ */
 import pkg from "../../package.json";
 
 export default function BuildInfo() {

--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -48,26 +48,28 @@ export default function LiveShopping({ channelId, onLike }) {
 
     //
     // ────────────────────────────────────────────────────────────────────────
-    // (A) Inject a <style> that hides all non-image fields
+    // (A) Inject a <style> that hides all non-image fields on devices without hover
     // ────────────────────────────────────────────────────────────────────────
-    injectedStyle = document.createElement("style");
-    injectedStyle.innerHTML = `
-      /* Hide everything except the two images */
-      .item-container [data-role="product-name"],
-      .item-container [data-role="product-price"],
-      .item-container [data-role="ai-description"],
-      .item-container [data-role="frame-image"],
-      .item-container [data-role="matchText"],
-      .item-container [data-role="vendor-logo"],
-      .item-container .info-button,
-      .item-container [data-role="like"],
-      .item-container [data-role="dislike"],
-      .item-container [data-role="share-link"],
-      .item-container [data-role="product-link"] {
-        display: none !important;
-      }
-    `;
-    document.head.appendChild(injectedStyle);
+    if (!deviceCanHover) {
+      injectedStyle = document.createElement("style");
+      injectedStyle.innerHTML = `
+        /* Hide everything except the two images */
+        .item-container [data-role="product-name"],
+        .item-container [data-role="product-price"],
+        .item-container [data-role="ai-description"],
+        .item-container [data-role="frame-image"],
+        .item-container [data-role="matchText"],
+        .item-container [data-role="vendor-logo"],
+        .item-container .info-button,
+        .item-container [data-role="like"],
+        .item-container [data-role="dislike"],
+        .item-container [data-role="share-link"],
+        .item-container [data-role="product-link"] {
+          display: none !important;
+        }
+      `;
+      document.head.appendChild(injectedStyle);
+    }
 
     // ────────────────────────────────────────────────────────────────────────
     // (C) Grab DOM nodes & bail if missing
@@ -224,7 +226,7 @@ export default function LiveShopping({ channelId, onLike }) {
       function makeCard(isP0 = false) {
         const wrapper = document.createElement("div");
         wrapper.innerHTML = renderToStaticMarkup(
-          <ProductCard isP0={isP0} />
+          <ProductCard isP0={isP0} showDetails={deviceCanHover} />
         );
         const card = wrapper.firstElementChild;
         if (card && deviceCanHover) {
@@ -266,7 +268,7 @@ export default function LiveShopping({ channelId, onLike }) {
       if (injectedScript) document.head.removeChild(injectedScript);
       if (injectedStyle) document.head.removeChild(injectedStyle);
     };
-  }, [channelId]);
+  }, [channelId, deviceCanHover]);
 
   // when mountFrame flips on, start the entry animation next tick
   useEffect(() => {
@@ -307,7 +309,7 @@ export default function LiveShopping({ channelId, onLike }) {
       {/* ─────────────────────────────────────────────────────────────────
            (2) DETAILS PANEL: visible when a card is in focus
       ───────────────────────────────────────────────────────────────── */}
-      <div className="live-details">
+      <div className="live-details" style={{ display: deviceCanHover ? "none" : "flex" }}>
         {selectedCardData.name ? (
           <>
             {/* (e) NAME */}

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -3,45 +3,60 @@ import LikeButton from "./buttons/LikeButton";
 import DislikeButton from "./buttons/DislikeButton";
 import ShareButton from "./buttons/ShareButton";
 
-export default function ProductCard({ isP0 }) {
+export default function ProductCard({ isP0, showDetails = false }) {
+  const hidden = showDetails ? {} : { display: "none" };
+
   return (
-<div className={`item-container ${isP0 ? "product0" : ""}`}>
+    <div
+      className={`item-container ${isP0 ? "product0" : ""} ${showDetails ? "show-details" : ""}`}
+    >
       <img data-role="product-image" src={null} alt="Product Image" loading="lazy" />
       <img className="frame-image" data-role="frame-image" src={null} alt="" />
-      <a data-role="product-link" href="" style={{ display: "none" }}></a>
-      <div
-        data-role="matchText"
-        style={{ display: "none", padding: "8px", fontSize: "1rem", fontWeight: "bold" }}
-      />
-      <img
-        data-role="vendor-logo"
-        src={null}
-        alt="Vendor Logo"
-        style={{ display: "none" }}
-      />
-      <div
-        data-role="product-name"
-        style={{ display: "none", padding: "8px", fontSize: "1rem", fontWeight: "bold" }}
-      />
-      <div
-        data-role="product-price"
-        style={{ display: "none", padding: "4px 8px", fontSize: "0.9rem", color: "#aaf" }}
-      />
-      <div
-        data-role="ai-description"
-        className="ai-query"
-        style={{ display: "none", padding: "8px", fontSize: "0.85rem", color: "#ddd" }}
-      />
-      <div
-        className="info-button"
-        style={{ display: "none", position: "absolute", top: 8, right: 8, color: "#fff", fontSize: "1.2rem" }}
-      >
-        &#9432;
-      </div>
-      <div style={{ display: "none", flex: 1, justifyContent: "space-around", padding: "8px 0" }}>
-        <LikeButton />
-        <DislikeButton />
-        <ShareButton />
+      <a data-role="product-link" href="" style={hidden}></a>
+      <div className="card-details live-details" style={showDetails ? {} : { display: "none" }}>
+        <div
+          data-role="matchText"
+          style={{ ...hidden, padding: "8px", fontSize: "1rem", fontWeight: "bold" }}
+        />
+        <img data-role="vendor-logo" src={null} alt="Vendor Logo" style={hidden} />
+        <div
+          data-role="product-name"
+          style={{ ...hidden, padding: "8px", fontSize: "1rem", fontWeight: "bold" }}
+        />
+        <div
+          data-role="product-price"
+          style={{ ...hidden, padding: "4px 8px", fontSize: "0.9rem", color: "#aaf" }}
+        />
+        <div
+          data-role="ai-description"
+          className="ai-query"
+          style={{ ...hidden, padding: "8px", fontSize: "0.85rem", color: "#ddd" }}
+        />
+        <div
+          className="info-button"
+          style={{
+            ...hidden,
+            position: "absolute",
+            top: 8,
+            right: 8,
+            color: "#fff",
+            fontSize: "1.2rem",
+          }}
+        >
+          &#9432;
+        </div>
+        <div
+          style={{
+            ...hidden,
+            flex: 1,
+            justifyContent: "space-around",
+            padding: "8px 0",
+          }}
+        >
+          <LikeButton />
+          <DislikeButton />
+          <ShareButton />
+        </div>
       </div>
     </div>
   );

--- a/src/components/ShoppingTab.jsx
+++ b/src/components/ShoppingTab.jsx
@@ -81,7 +81,7 @@ export default function ShoppingTab({ channelId, openProfileSidebar }) {
         className="subtab-section"
         style={{ position: "relative", width: "100%", height: "100%" }}
       >
-        {nestedConfig.map(({ key, Component }, i) => {
+        {nestedConfig.map(({ key }, i) => {
           // pass props into FavouritesTab only
           if (key === "favourites") {
             return (

--- a/src/hooks/useChannelId.js
+++ b/src/hooks/useChannelId.js
@@ -12,7 +12,9 @@ export function useChannelId() {
     // always store the final value
     try {
       localStorage.setItem("channelId", id);
-    } catch {}
+    } catch {
+      // ignore write errors
+    }
 
     return id;
   }, []);

--- a/src/pages/AppPage.jsx
+++ b/src/pages/AppPage.jsx
@@ -114,18 +114,21 @@ export default function AppPage() {
           overflow: "hidden",
         }}
       >
-        {tabConfig.map(({ key, Component }, i) => (
-          <div key={key} className="tab-content" ref={panelRefs.current[i]}>
-            {key === "shopping" ? (
-              <Component
-                channelId={channelId}
-                openProfileSidebar={handleToggleSidebar}
-              />
-            ) : (
-              <Component />
-            )}
-          </div>
-        ))}
+        {tabConfig.map(({ key, Component: TabComponent }, i) => {
+          void TabComponent;
+          return (
+            <div key={key} className="tab-content" ref={panelRefs.current[i]}>
+              {key === "shopping" ? (
+                <TabComponent
+                  channelId={channelId}
+                  openProfileSidebar={handleToggleSidebar}
+                />
+              ) : (
+                <TabComponent />
+              )}
+            </div>
+          );
+        })}
       </section>
 
       <Tabs

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -424,3 +424,38 @@ section {
   align-items: center;
   padding: 3px;
 }
+
+/* Product card details displayed on hover devices */
+.item-container.show-details {
+  flex-direction: column;
+  align-items: stretch;
+  height: auto;
+}
+
+.item-container.show-details .card-details {
+  display: flex;
+}
+
+.card-details {
+  display: none;
+  border-radius: 8px;
+  color: #fff;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  padding: 10px;
+  gap: 10px;
+}
+
+.card-details [data-role="product-name"] {
+  font-size: 0.9rem;
+  line-height: 1.2rem;
+  min-height: 3.6rem;
+  font-weight: 600;
+  color: var(--color-light);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+/* global process */
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- show item details within `ProductCard` on devices that support hover
- hide the sidebar details panel when a device can hover
- expose hover capability to the card factory
- tweak default hooks and configs for lint
- update build info and configuration globals
- style `card-details` container for in-card details

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f935eaf508323860dd18d00e21961