### PR TITLE
Fix social buttons in desktop product cards

### DIFF
--- a/src/components/buttons/DislikeButton.jsx
+++ b/src/components/buttons/DislikeButton.jsx
@@ -9,15 +9,44 @@ export default function DislikeButton({ itemId, itemTypeName, onSuccess }) {
   const { user } = useAuth();
   const { openSidebar } = useSidebar();
 
+  function inferItemTypeName(card) {
+    const url =
+      card?.querySelector("[data-role='product-link']")?.href?.toLowerCase() || "";
+    if (card?.classList.contains("ticket-style")) {
+      return url.includes("viator") ? "Viator Ticket" : "DB Ticket";
+    }
+    if (card?.classList.contains("coupon-style")) {
+      return "Deal";
+    }
+    return "DB Product";
+  }
+
   const handleClick = async (e) => {
     e.stopPropagation();
     if (!user) return openSidebar();
-    await downvoteProduct(itemId, itemTypeName);
-    onSuccess?.(); // bump refresh
+
+    let id = itemId;
+    let typeName = itemTypeName;
+
+    if (!id) {
+      const card = e.currentTarget.closest(".item-container");
+      id = card?.getAttribute("data-product-id");
+      typeName = inferItemTypeName(card);
+    }
+
+    if (!id) return;
+
+    await downvoteProduct(id, typeName);
+    onSuccess?.();
   };
 
   return (
-    <button className="product-cta" data-role="dislike" onClick={handleClick}>
+    <button
+      className="product-cta dislike-button"
+      data-role="dislike"
+      data-product-id={itemId}
+      onClick={handleClick}
+    >
       <SvgDislike />
     </button>
   );

--- a/src/components/buttons/LikeButton.jsx
+++ b/src/components/buttons/LikeButton.jsx
@@ -9,15 +9,44 @@ export default function LikeButton({ itemId, itemTypeName, onSuccess }) {
   const { user } = useAuth();
   const { openSidebar } = useSidebar();
 
+  function inferItemTypeName(card) {
+    const url =
+      card?.querySelector("[data-role='product-link']")?.href?.toLowerCase() || "";
+    if (card?.classList.contains("ticket-style")) {
+      return url.includes("viator") ? "Viator Ticket" : "DB Ticket";
+    }
+    if (card?.classList.contains("coupon-style")) {
+      return "Deal";
+    }
+    return "DB Product";
+  }
+
   const handleClick = async (e) => {
     e.stopPropagation();
     if (!user) return openSidebar();
-    await upvoteProduct(itemId, itemTypeName);
+
+    let id = itemId;
+    let typeName = itemTypeName;
+
+    if (!id) {
+      const card = e.currentTarget.closest(".item-container");
+      id = card?.getAttribute("data-product-id");
+      typeName = inferItemTypeName(card);
+    }
+
+    if (!id) return;
+
+    await upvoteProduct(id, typeName);
     onSuccess?.();
   };
 
   return (
-    <button className="product-cta" data-role="like" onClick={handleClick}>
+    <button
+      className="product-cta like-button"
+      data-role="like"
+      data-product-id={itemId}
+      onClick={handleClick}
+    >
       <SvgLike />
     </button>
   );

--- a/src/components/buttons/ShareButton.jsx
+++ b/src/components/buttons/ShareButton.jsx
@@ -5,16 +5,29 @@ import SvgShare from "../svgs/SvgShare";
 export default function ShareButton({ title, url }) {
   const handleClick = (e) => {
     e.stopPropagation();
+
+    let shareTitle = title;
+    let shareUrl = url;
+
+    if (!shareUrl) {
+      const card = e.currentTarget.closest(".item-container");
+      shareTitle =
+        shareTitle ||
+        card?.querySelector("[data-role='product-name']")?.innerText ||
+        "";
+      shareUrl = card?.querySelector("[data-role='product-link']")?.href || "";
+    }
+
     if (navigator.share) {
-      navigator.share({ title, text: title, url });
+      navigator.share({ title: shareTitle, text: shareTitle, url: shareUrl });
     } else {
-      navigator.clipboard.writeText(url).then(() => alert("Link copied!"));
+      navigator.clipboard.writeText(shareUrl).then(() => alert("Link copied!"));
     }
   };
 
   return (
     <button
-      className="product-cta"
+      className="product-cta share-button"
       data-role="share-link"
       onClick={handleClick}
     >


### PR DESCRIPTION
## Summary
- improve LikeButton logic to read ID and type from DOM if not provided
- improve DislikeButton logic similarly
- update ShareButton to fallback to DOM for title and URL and add classes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ffbbf14a883239181a2950226b466