### PR TITLE
Fix AI frame rendering

### DIFF
--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -36,7 +36,6 @@ export default function LiveShopping({ channelId, onLike }) {
   });
 
   // ───────── Mount & animate frame states ─────────
-  const [mountFrame, setMountFrame] = useState(false);
   const [animateFrame, setAnimateFrame] = useState(false);
 
   // ───────── Detect hover (desktop vs mobile) ─────────
@@ -232,6 +231,22 @@ export default function LiveShopping({ channelId, onLike }) {
         if (card && deviceCanHover) {
           card.addEventListener("mouseenter", () => applyFocus(card));
         }
+
+        const toggle = card.querySelector('[data-role="frame-toggle"]');
+        const container = card.querySelector('[data-role="frame-container"]');
+        const text = card.querySelector('[data-role="toggle-text"]');
+        if (toggle && container) {
+          let visible = false;
+          toggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            visible = !visible;
+            container.style.maxHeight = visible ? '200px' : '0px';
+            container.style.opacity = visible ? '1' : '0';
+            container.style.transform = visible ? 'translateY(0)' : 'translateY(-20px)';
+            if (text) text.textContent = visible ? 'Hide Frame' : 'Show Frame';
+          });
+        }
+
         return card;
       }
 
@@ -270,28 +285,11 @@ export default function LiveShopping({ channelId, onLike }) {
     };
   }, [channelId, deviceCanHover]);
 
-  // when mountFrame flips on, start the entry animation next tick
-  useEffect(() => {
-    if (mountFrame) {
-      requestAnimationFrame(() => {
-        setAnimateFrame(true);
-      });
-    }
-  }, [mountFrame]);
-
-  // when animateFrame flips off, unmount after the transition finishes
-  useEffect(() => {
-    if (!animateFrame && mountFrame) {
-      const timer = setTimeout(() => setMountFrame(false), 400);
-      return () => clearTimeout(timer);
-    }
-  }, [animateFrame, mountFrame]);
 
   // ───────── Hide frame when user focuses a different product ─────────
   useEffect(() => {
-    // collapse and unmount immediately
+    // collapse immediately
     setAnimateFrame(false);
-    setMountFrame(false);
   }, [selectedCardData.id]);
 
   // ─────────────────────────────────────────────────────────────────
@@ -350,11 +348,7 @@ export default function LiveShopping({ channelId, onLike }) {
                 {/* Inline toggle */}
                 <button
                   onClick={() => {
-                    if (!mountFrame) {
-                      setMountFrame(true);
-                    } else {
-                      setAnimateFrame(false);
-                    }
+                    setAnimateFrame((prev) => !prev);
                   }}
                   style={{
                     display: "inline-flex",
@@ -375,7 +369,7 @@ export default function LiveShopping({ channelId, onLike }) {
             </p>
 
             {/* (d-1) FRAME IMAGE: only when toggled on */}
-            {mountFrame && selectedCardData.frameImageUrl && (
+            {selectedCardData.frameImageUrl && (
               <div
                 className="live-frame-image-container"
                 style={{

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import LikeButton from "./buttons/LikeButton";
 import DislikeButton from "./buttons/DislikeButton";
 import ShareButton from "./buttons/ShareButton";
@@ -6,6 +6,14 @@ import SvgFrame from "./svgs/SvgFrame";
 
 export default function ProductCard({ isP0, showDetails = false }) {
   const hidden = showDetails ? {} : { display: "none" };
+  const [animateFrame, setAnimateFrame] = useState(false);
+
+  // collapse the frame when details hide
+  useEffect(() => {
+    if (!showDetails) {
+      setAnimateFrame(false);
+    }
+  }, [showDetails]);
 
   return (
     <div
@@ -79,13 +87,10 @@ export default function ProductCard({ isP0, showDetails = false }) {
               />
             </span>
             {/* Inline toggle */}
-            {/*  <button
+            <button
+              data-role="frame-toggle"
               onClick={() => {
-                if (!mountFrame) {
-                  setMountFrame(true);
-                } else {
-                  setAnimateFrame(false);
-                }
+                setAnimateFrame((prev) => !prev);
               }}
               style={{
                 display: "inline-flex",
@@ -99,34 +104,36 @@ export default function ProductCard({ isP0, showDetails = false }) {
               }}
             >
               <SvgFrame style={{ marginRight: "4px", flexShrink: 0 }} />
-              {animateFrame ? "Hide Frame" : "Show Frame"}
-            </button> */}
+              <span data-role="toggle-text">
+                {animateFrame ? "Hide Frame" : "Show Frame"}
+              </span>
+            </button>
           </span>
         </p>
-        {/* <div
-          className="live-frame-image-container"
-          style={{
-            overflow: "hidden",
-            aspectRatio: "16/9",
-            maxWidth: "calc(200px * 16 / 9)",
-            width: "fit-content",
-            //maxHeight: animateFrame ? "200px" : "0px",
-            objectFit: "cover",
-            borderRadius: "8px",
-            //opacity: animateFrame ? 1 : 0,
-            //transform: animateFrame ? "translateY(0)" : "translateY(-20px)",
-            transition:
-              "opacity 0.4s ease, transform 0.4s ease, max-height 0.4s ease",
-          }}
-        >
-          {" "}
-          <img
-            className="live-frame-image"
-            data-role="frame-image"
-            src={null}
-            alt=""
-          />
-        </div> */}
+        <div
+            className="live-frame-image-container"
+            data-role="frame-container"
+            style={{
+              overflow: "hidden",
+              aspectRatio: "16/9",
+              maxWidth: "calc(200px * 16 / 9)",
+              width: "fit-content",
+              maxHeight: animateFrame ? "200px" : "0px",
+              objectFit: "cover",
+              borderRadius: "8px",
+              opacity: animateFrame ? 1 : 0,
+              transform: animateFrame ? "translateY(0)" : "translateY(-20px)",
+              transition:
+                "opacity 0.4s ease, transform 0.4s ease, max-height 0.4s ease",
+            }}
+          >
+            <img
+              className="live-frame-image"
+              data-role="frame-image"
+              src={null}
+              alt=""
+            />
+          </div>
 
         <p
           style={{


### PR DESCRIPTION
## Summary
- keep AI frame element always mounted in `ProductCard.jsx`
- simplify frame toggle logic in `LiveShopping.jsx`
- add DOM-based toggle for desktop cards

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ffa8a1a3c8323a360388fa8708d55