### PR TITLE
Fix sidebar close when triggered from like buttons

### DIFF
--- a/src/components/FavoritesTab.jsx
+++ b/src/components/FavoritesTab.jsx
@@ -2,14 +2,12 @@
 import React, { useEffect, useRef } from "react";
 import { useFavorites } from "../contexts/FavoritesContext";
 import { useAuth } from "../contexts/AuthContext";
+import { useSidebar } from "../contexts/SidebarContext";
 
-export default function FavouritesTab({
-  refreshKey,
-  onNavigateToLive,
-  openProfileSidebar,
-}) {
+export default function FavouritesTab({ refreshKey, onNavigateToLive }) {
   const { favorites, removeFavorite, fetchFavorites } = useFavorites();
   const { user } = useAuth();
+  const { openSidebar } = useSidebar();
   const containerRef = useRef(null);
   const pullStartY = useRef(null);
 
@@ -70,7 +68,7 @@ export default function FavouritesTab({
           <p style={{ marginBottom: "1rem", color: "#fff", lineHeight: "1.5" }}>
             Sign in to see your Favorite Products
           </p>
-          <button onClick={openProfileSidebar} className="favorites-cta">
+          <button onClick={openSidebar} className="favorites-cta">
             Sign In
           </button>
         </div>

--- a/src/components/ShoppingTab.jsx
+++ b/src/components/ShoppingTab.jsx
@@ -4,7 +4,7 @@ import HomeTab from "./HomeTab";
 import LiveShopping from "./LiveShopping";
 import FavouritesTab from "./FavoritesTab";
 
-export default function ShoppingTab({ channelId, openProfileSidebar }) {
+export default function ShoppingTab({ channelId }) {
   const nestedConfig = useMemo(
     () => [
       { key: "live", label: "Live", Component: LiveShopping },
@@ -96,7 +96,6 @@ export default function ShoppingTab({ channelId, openProfileSidebar }) {
                 <FavouritesTab
                   refreshKey={refreshFavouritesKey}
                   onNavigateToLive={() => setActive("live")}
-                  openProfileSidebar={openProfileSidebar}
                 />
               </div>
             );

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -1,12 +1,9 @@
 // src/components/Tabs.jsx
 import React from "react";
+import { useSidebar } from "../contexts/SidebarContext";
 
-export default function Tabs({
-  tabs,
-  activeTab,
-  onChangeTab,
-  onToggleSidebar,
-}) {
+export default function Tabs({ tabs, activeTab, onChangeTab }) {
+  const { openSidebar } = useSidebar();
   return (
     <footer className="footer">
       {/* (j) AFFILIATE FOOTER */}
@@ -27,7 +24,7 @@ export default function Tabs({
         {/* Sidebar‐toggle button inside the tabs row */}
         <button
           className="tab sidebar-toggle"
-          onClick={onToggleSidebar}
+          onClick={openSidebar}
           aria-label="Toggle profile sidebar"
         >
           <div className="avatar-wrapper small">

--- a/src/pages/AppPage.jsx
+++ b/src/pages/AppPage.jsx
@@ -1,8 +1,7 @@
 // src/pages/AppPage.jsx
-import React, { useState, useRef, useEffect, useMemo } from "react";
+import React, { useRef, useEffect, useMemo, useState } from "react";
 import AppHeader from "../components/AppHeader";
 import Tabs from "../components/Tabs";
-import ProfileSidebar from "../components/ProfileSidebar";
 
 // Tab‐pane components
 import ShoppingTab from "../components/ShoppingTab";
@@ -42,12 +41,8 @@ export default function AppPage() {
     []
   );
 
-  // active tab & sidebar state
+  // active tab state
   const [activeTab, setActiveTab] = useState(tabConfig[0].key);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-
-  const handleToggleSidebar = () => setIsSidebarOpen((o) => !o);
-  const handleCloseSidebar = () => setIsSidebarOpen(false);
 
   // refs for sliding panels
   const prevIndexRef = useRef(0);
@@ -108,7 +103,7 @@ export default function AppPage() {
 
   return (
     <>
-      <AppHeader onToggleSidebar={handleToggleSidebar} />
+      <AppHeader />
 
       <section
         style={{
@@ -122,10 +117,7 @@ export default function AppPage() {
           return (
             <div key={key} className="tab-content" ref={panelRefs.current[i]}>
               {key === "shopping" ? (
-                <TabComponent
-                  channelId={channelId}
-                  openProfileSidebar={handleToggleSidebar}
-                />
+                <TabComponent channelId={channelId} />
               ) : (
                 <TabComponent />
               )}
@@ -134,14 +126,8 @@ export default function AppPage() {
         })}
       </section>
 
-      <Tabs
-        tabs={tabConfig}
-        activeTab={activeTab}
-        onChangeTab={setActiveTab}
-        onToggleSidebar={handleToggleSidebar}
-      />
+      <Tabs tabs={tabConfig} activeTab={activeTab} onChangeTab={setActiveTab} />
 
-      <ProfileSidebar isOpen={isSidebarOpen} onClose={handleCloseSidebar} />
       <AppBg />
     </>
   );


### PR DESCRIPTION
## Summary
- remove duplicate sidebar state in `AppPage`
- open sidebar from global context in `Tabs`, `ShoppingTab`, and `FavoritesTab`
- connect "Sign In" CTA to global sidebar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850526a4c888323807f88905cbc5dad