### PR TITLE
Fix empty paragraph in ProductCard

### DIFF
--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -40,7 +40,7 @@ export default function ProductCard({ isP0, showDetails = false }) {
           }}
         />
 
-        <p
+        <div
           style={{
             display: "flex",
             flexDirection: "column",
@@ -108,7 +108,7 @@ export default function ProductCard({ isP0, showDetails = false }) {
               />
             </span>
           </span>
-        </p>
+        </div>
         <div
           className="live-frame-image-container"
           data-role="frame-container"


### PR DESCRIPTION
## Summary
- avoid invalid markup causing an empty paragraph

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68509e5ff0c483238a393666a38e4daa