### PR TITLE
Add basic home page and update routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,7 +36,7 @@ export default function App() {
         <Route path="/oauth2callback" element={<OAuthCallback />} />
 
         {/* 2) Default landing */}
-        <Route index element={<Navigate to="/app" replace />} />
+        <Route index element={<Navigate to="/home" replace />} />
 
         {/* 3) Top‐level pages */}
         <Route path="/app" element={<AppPage />} />
@@ -46,7 +46,7 @@ export default function App() {
         <Route path="/home" element={<HomePage />} />
 
         {/* 4) Fallback */}
-        <Route path="*" element={<Navigate to="/app" replace />} />
+        <Route path="*" element={<Navigate to="/home" replace />} />
       </Routes>
       <BuildInfo />
     </>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,6 +15,7 @@ import "./styles/FAQ.css";
 import "./styles/liveShoppingDesktop.css";
 import "./styles/liveShoppingTablet.css";
 import "./styles/scrollBar.css";
+import "./styles/HomePage.css";
 
 import App from "./App";
 import { AuthProvider } from "./contexts/AuthContext";

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,7 +1,49 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import EdgeLogo from "../assets/edgevideoai-logo.png";
+import "../styles/HomePage.css";
 
-const HomePage = () => {
-  return <div>HomePage</div>;
-};
+export default function HomePage() {
+  return (
+    <div className="home-container">
+      <header className="site-header">
+        <Link to="/home" className="logo-link">
+          <img src={EdgeLogo} alt="Edge Video" height="40" />
+        </Link>
+        <nav className="site-nav">
+          <Link to="/app" className="nav-link">
+            Launch App
+          </Link>
+        </nav>
+      </header>
 
-export default HomePage;
+      <section className="hero">
+        <h1>Join The Shoppable Video Revolution</h1>
+        <p>
+          Our AI-powered shoppable broadcasting solution adds a new dimension to
+          any video stream and allows viewers to purchase items in real-time from
+          their favorite shows—without leaving the screen.
+        </p>
+        <a href="mailto:info@edgevideo.ai" className="cta-button">
+          Contact Us
+        </a>
+        <img
+          className="hero-img"
+          src="https://cdn.prod.website-files.com/65dc7230257517ba67df2f52/67e716ffa7eb0dcfa13904aa_1_hero-smaller.png"
+          alt="Edge Video Demo"
+        />
+      </section>
+
+      <section className="features">
+        <div className="feature-item">
+          <h2>Edge Video AI in Action</h2>
+          <p>
+            Transform any stream into an interactive shopping experience. Engage
+            your audience and convert views into sales with built-in games and
+            real-time purchases.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/styles/HomePage.css
+++ b/src/styles/HomePage.css
@@ -1,0 +1,50 @@
+.home-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #fff;
+  padding: 1rem;
+}
+
+.site-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.site-nav .nav-link {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  max-width: 800px;
+}
+
+.hero-img {
+  max-width: 100%;
+  height: auto;
+}
+
+.cta-button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-primary, #d91e70);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.features {
+  margin-top: 3rem;
+  max-width: 800px;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- implement initial `HomePage` with hero section and call to action
- create `HomePage.css` for simple styling
- include `HomePage.css` in global styles
- update routes so `/home` is the default landing page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850a8c7e93483238d0e87d7efb4f5af