### PR TITLE
Fix hover detection for mobile devices

### DIFF
--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -42,7 +42,7 @@ export default function LiveShopping({ channelId, onLike }) {
   const [animateFrame, setAnimateFrame] = useState(false);
 
   // ───────── Detect hover (desktop vs mobile) ─────────
-  const deviceCanHover = window.matchMedia("(any-hover:hover)").matches;
+  const deviceCanHover = window.matchMedia("(hover: hover)").matches;
 
   const { user } = useAuth();
   const { openSidebar } = useSidebar();

--- a/src/styles/liveShoppingDesktop.css
+++ b/src/styles/liveShoppingDesktop.css
@@ -1,6 +1,6 @@
 /* Live Shopping Desktop CSS */
 
-@media (any-hover: hover) {
+@media (hover: hover) {
   #clicked-list .product-card {
     flex: 0 0 200px;
   }

--- a/src/styles/liveShoppingTablet.css
+++ b/src/styles/liveShoppingTablet.css
@@ -1,6 +1,6 @@
 /* Live Shopping Desktop CSS */
 
-@media (any-hover: hover) and (max-width: 860px) {
+@media (hover: hover) and (max-width: 860px) {
   #itemContent {
     gap: 10px;
   }


### PR DESCRIPTION
## Summary
- use `(hover: hover)` to detect hover capability
- update styles to also rely on `(hover: hover)`

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518ef594ac8323ae433e7e18b76598