### PR TITLE
Fix OAuth callback path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ export default function App() {
       <Routes>
         {/* 1) OAuth callback */}
         <Route path="/oauth2callback" element={<OAuthCallback />} />
+        <Route path="/app/oauth2callback" element={<OAuthCallback />} />
 
         {/* 2) Default landing */}
         <Route index element={<Navigate to="/home" replace />} />


### PR DESCRIPTION
## Summary
- add a route for `/app/oauth2callback` so production redirects work

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518f5d56e0832392e6296e06aac6e5