### PR TITLE
Fix desktop focus jump after liking product

### DIFF
--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -47,9 +47,13 @@ export default function LiveShopping({ channelId, onLike }) {
   const { user } = useAuth();
   const { openSidebar } = useSidebar();
   const userRef = useRef(user);
+  const onLikeRef = useRef(onLike);
+  const sidebarRef = useRef(openSidebar);
   useEffect(() => {
     userRef.current = user;
-  }, [user]);
+    onLikeRef.current = onLike;
+    sidebarRef.current = openSidebar;
+  }, [user, onLike, openSidebar]);
 
   function inferItemTypeName(target) {
     const url =
@@ -65,35 +69,29 @@ export default function LiveShopping({ channelId, onLike }) {
     return "DB Product";
   }
 
-  const handleLike = useCallback(
-    async (e) => {
-      e.stopPropagation();
-      if (!userRef.current) return openSidebar();
+  const handleLike = useCallback(async (e) => {
+    e.stopPropagation();
+    if (!userRef.current) return sidebarRef.current();
 
-      const card = e.currentTarget.closest(".item-container");
-      const id = card?.getAttribute("data-product-id");
-      if (!id) return;
+    const card = e.currentTarget.closest(".item-container");
+    const id = card?.getAttribute("data-product-id");
+    if (!id) return;
 
-      await upvoteProduct(id, inferItemTypeName(card));
-      onLike?.();
-    },
-    [openSidebar, onLike]
-  );
+    await upvoteProduct(id, inferItemTypeName(card));
+    onLikeRef.current?.();
+  }, []);
 
-  const handleDislike = useCallback(
-    async (e) => {
-      e.stopPropagation();
-      if (!userRef.current) return openSidebar();
+  const handleDislike = useCallback(async (e) => {
+    e.stopPropagation();
+    if (!userRef.current) return sidebarRef.current();
 
-      const card = e.currentTarget.closest(".item-container");
-      const id = card?.getAttribute("data-product-id");
-      if (!id) return;
+    const card = e.currentTarget.closest(".item-container");
+    const id = card?.getAttribute("data-product-id");
+    if (!id) return;
 
-      await downvoteProduct(id, inferItemTypeName(card));
-      onLike?.();
-    },
-    [openSidebar, onLike]
-  );
+    await downvoteProduct(id, inferItemTypeName(card));
+    onLikeRef.current?.();
+  }, []);
 
   const handleShare = useCallback((e) => {
     e.stopPropagation();


### PR DESCRIPTION
## Summary
- keep `onLike` and `openSidebar` references stable in `LiveShopping`
- update like/dislike handlers to use those refs so the main effect doesn't rerun unnecessarily

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a54e6f848323ab4529bbd5290abd