### PR TITLE
Refactor vote utils and optimize screen

### DIFF
--- a/src/contexts/FavoritesContext.jsx
+++ b/src/contexts/FavoritesContext.jsx
@@ -6,11 +6,12 @@ import React, {
   useCallback,
 } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { getItemTypeNameFromId } from "../services/voteService";
-
-const VOTES_PRODUCTS = "https://fastapi.edgevideo.ai/tracking/votes/products";
-const VOTES_VIATOR = "https://fastapi.edgevideo.ai/tracking/votes/viator";
-const DOWNVOTE_URL = "https://fastapi.edgevideo.ai/tracking/vote/down";
+import {
+  getItemTypeNameFromId,
+  VOTED_PRODUCTS_URL,
+  VOTED_VIATOR_URL,
+  DOWNVOTE_URL,
+} from "../services/voteService";
 
 const FavoritesContext = createContext({
   favorites: [],
@@ -32,8 +33,8 @@ export function FavoritesProvider({ children }) {
       const token = localStorage.getItem("authToken");
       const opts = { headers: { Authorization: `Bearer ${token}` } };
       const [r1, r2] = await Promise.all([
-        fetch(VOTES_PRODUCTS, opts),
-        fetch(VOTES_VIATOR, opts),
+        fetch(VOTED_PRODUCTS_URL, opts),
+        fetch(VOTED_VIATOR_URL, opts),
       ]);
       if (!r1.ok || !r2.ok) throw new Error("Failed to fetch votes");
       const [a1, a2] = await Promise.all([r1.json(), r2.json()]);

--- a/src/legacy/modules/products.js
+++ b/src/legacy/modules/products.js
@@ -126,3 +126,17 @@ export function FormatPrice(price, currency = "USD") {
   }
   return position === "prefix" ? `${symbol}${formattedPrice}` : `${formattedPrice}${symbol}`;
 }
+
+export function AddClassToAll(element, className) {
+  element.classList.add(className);
+  element.querySelectorAll("*").forEach((child) => {
+    child.classList.add(className);
+  });
+}
+
+export function RemoveClassFromAll(element, className) {
+  element.classList.remove(className);
+  element.querySelectorAll("*").forEach((child) => {
+    child.classList.remove(className);
+  });
+}

--- a/src/services/voteService.js
+++ b/src/services/voteService.js
@@ -1,7 +1,9 @@
 // src/services/voteService.js
-const BASE = "https://fastapi.edgevideo.ai/tracking";
-const UPVOTE_URL = `${BASE}/vote/up`;
-const DOWNVOTE_URL = `${BASE}/vote/down`;
+export const BASE = "https://fastapi.edgevideo.ai/tracking";
+export const UPVOTE_URL = `${BASE}/vote/up`;
+export const DOWNVOTE_URL = `${BASE}/vote/down`;
+export const VOTED_PRODUCTS_URL = `${BASE}/votes/products`;
+export const VOTED_VIATOR_URL = `${BASE}/votes/viator`;
 
 function normalizeItemTypeName(name) {
   if (!name) return "DB Product";


### PR DESCRIPTION
## Summary
- centralize vote URLs and utilities in `voteService.js`
- share vote constants with `FavoritesContext`
- cache DOM lookups in `UpdateProductViaDataRole`
- expose class helpers from `products.js`
- adjust downvote flow to reuse `voteService`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853183a5e24832380acd6bc55c2bde6