### PR TITLE
Refactor screen initializer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 // src/App.jsx
 import React, { Suspense, lazy } from "react";
-import ScreenInitializer from "./screen/ScreenInitializer";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import ProfileSidebar from "./components/ProfileSidebar";
 import { useSidebar } from "./contexts/SidebarContext";
@@ -28,8 +27,6 @@ export default function App() {
       {showSidebar && (
         <ProfileSidebar isOpen={sidebarOpen} onClose={closeSidebar} />
       )}
-
-      <ScreenInitializer />
 
       <Suspense fallback={<div />}>
         <Routes>

--- a/src/legacy/screen.js
+++ b/src/legacy/screen.js
@@ -1169,23 +1169,26 @@ function populateFavoritesTab() {
 
 // --- NEW: Main Initialization Function ---
 function initializeApp() {
-  edgeConsole.log("DOM ready, initializing application..."); // Log initialization start
+  edgeConsole.log("DOM ready, initializing application...");
 
-  // Start WebSocket connection
+  initProductsFeature();
+  initFacesFeature();
+  initAuthFeature();
+
+  hideConsoleMessages();
+}
+
+export function initProductsFeature() {
   initializeWebSocket();
-
-  // Fetch initial product data
   getCachedProducts();
+}
 
-  // Start the interval timer for updating faces
-  // Ensure UpdateFaces itself handles null elements gracefully if called before elements exist
+export function initFacesFeature() {
   setInterval(UpdateFaces, 1000);
+}
 
-  // Set up the login/auth related UI and logic
+export function initAuthFeature() {
   setupLoginHandling(fetchVotedProducts, populateFavoritesTab);
-
-  // Any other initialization code that depends on the DOM should go here
-  hideConsoleMessages(); // Call this after DOM ready if it depends on anything
 }
 
 export function startScreen() {

--- a/src/pages/AppPage.jsx
+++ b/src/pages/AppPage.jsx
@@ -3,6 +3,7 @@ import React, { useState, useRef, useEffect, useMemo } from "react";
 import AppHeader from "../components/AppHeader";
 import Tabs from "../components/Tabs";
 import ProfileSidebar from "../components/ProfileSidebar";
+import ScreenInitializer from "../screen/ScreenInitializer";
 
 // Tab‐pane components
 import ShoppingTab from "../components/ShoppingTab";
@@ -109,6 +110,7 @@ export default function AppPage() {
 
   return (
     <>
+      <ScreenInitializer features={["products", "faces", "auth"]} />
       <AppHeader onToggleSidebar={handleToggleSidebar} />
 
       <section

--- a/src/screen/ScreenInitializer.jsx
+++ b/src/screen/ScreenInitializer.jsx
@@ -1,9 +1,20 @@
 import { useEffect } from "react";
-import { startScreen } from "../legacy/screen";
-
-export default function ScreenInitializer() {
+import {
+  initProductsFeature,
+  initFacesFeature,
+  initAuthFeature,
+} from "../legacy/screen";
+export default function ScreenInitializer({ features = [] }) {
   useEffect(() => {
-    startScreen();
-  }, []);
+    if (features.includes("products")) {
+      initProductsFeature();
+    }
+    if (features.includes("faces")) {
+      initFacesFeature();
+    }
+    if (features.includes("auth")) {
+      initAuthFeature();
+    }
+  }, [features]);
   return null;
 }


### PR DESCRIPTION
## Summary
- export fine-grained init functions from legacy screen module
- call required initializers in new `ScreenInitializer` component
- remove global screen initialization
- run initialization only on `AppPage`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c543b817c83239e4960a767cac96a