### PR TITLE
Add fallback logo when channel logo fetch fails

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,4 @@ VITE_GOOGLE_CLIENT_ID=660421509834-ejemlgtvmt15ppa35p8v1adaltfnupki.apps.googleu
 VITE_REDIRECT_URI=https://edgevideo-ai-8753a.web.app/app/oauth2callback
 VITE_USERINFO_URL=https://fastapi.edgevideo.ai/auth_google/details
 VITE_AUTH_BASE_URL=https://fastapi.edgevideo.ai/auth_google
+VITE_STUDIO_API_URL=https://studio-api.edgevideo.com

--- a/src/components/ChannelLogo.jsx
+++ b/src/components/ChannelLogo.jsx
@@ -1,4 +1,9 @@
 import React, { useState, useEffect } from "react";
+import fallbackLogo from "../assets/edgevideoai-logo.png";
+
+const API_BASE =
+  import.meta.env.VITE_STUDIO_API_URL ||
+  "https://studio-api.edgevideo.com";
 
 /**
  * ChannelLogo
@@ -26,7 +31,7 @@ export default function ChannelLogo({
     async function fetchLogo() {
       try {
         const res = await fetch(
-          `https://studio-api.edgevideo.com/channel/loadChannelLogo/${channel}`
+          `${API_BASE}/channel/loadChannelLogo/${channel}`
         );
         if (!res.ok) throw new Error(`Status ${res.status}`);
         const json = await res.json();
@@ -35,7 +40,11 @@ export default function ChannelLogo({
         if (!cancelled) setLogoUrl(logo);
       } catch (err) {
         console.error("ChannelLogo fetch error:", err);
-        if (!cancelled) setError("Failed to load channel logo");
+        if (!cancelled) {
+          // fall back to bundled logo
+          setLogoUrl(fallbackLogo);
+          setError(null);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- fetch channel logo from configurable API
- use local logo if remote fetch fails
- allow overriding channel logo endpoint via `.env`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c710e6ddc83239e907804feb99405