### PR TITLE
Improve AppPage styling load

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/edge-video-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preload" href="/src/styles/app.css" as="style" />
     <title>Edge Video AI</title>
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import React, { Suspense, lazy } from "react";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import ProfileSidebar from "./components/ProfileSidebar";
 import { useSidebar } from "./contexts/SidebarContext";
+import LoadingOverlay from "./components/LoadingOverlay";
 
 // Page components
 const AppPage = lazy(() => import("./pages/AppPage"));
@@ -28,7 +29,7 @@ export default function App() {
         <ProfileSidebar isOpen={sidebarOpen} onClose={closeSidebar} />
       )}
 
-      <Suspense fallback={<div />}>
+      <Suspense fallback={<LoadingOverlay />}>
         <Routes>
         {/* 1) OAuth callback */}
         <Route path="/oauth2callback" element={<OAuthCallback />} />

--- a/src/auth/LogoutButton.jsx
+++ b/src/auth/LogoutButton.jsx
@@ -1,6 +1,5 @@
 // src/auth/LogoutButton.jsx
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
 export default function LogoutButton() {

--- a/src/components/LoadingOverlay.jsx
+++ b/src/components/LoadingOverlay.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import "../styles/loading.css";
+
+export default function LoadingOverlay() {
+  return (
+    <div className="loading-overlay">
+      <div className="loading-spinner" />
+    </div>
+  );
+}

--- a/src/styles/loading.css
+++ b/src/styles/loading.css
@@ -1,0 +1,27 @@
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 9999;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  animation: loading-spin 1s linear infinite;
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- preload `app.css` to speed up AppPage styles
- show a loading overlay while lazy pages load
- clean up unused import in LogoutButton

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c8190c3b88323bf3e231b62e89d39