### PR TITLE
Show all products in separate details panel

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -467,6 +467,13 @@ section {
   white-space: normal;
 }
 
+.all-live-details {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 10px;
+}
+
 /* Quick Access Tab */
 .quick-access-list {
   list-style: none;


### PR DESCRIPTION
## Summary
- add `DetailsPanel` component for reusable product details UI
- collect card data in a `useCallback`
- maintain `allCardData` array and append when cards load
- render list of details with new `.all-live-details` styles
- style `.all-live-details` container

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860511adc84832385ddf37d219c6075