### PR TITLE
Add AI details container

### DIFF
--- a/src/components/AiDetails.jsx
+++ b/src/components/AiDetails.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export default function AiDetails({ data }) {
+  if (!data) return null;
+  return (
+    <div className="ai-details-panel">
+      {data.matchText && (
+        <div style={{ fontSize: "1rem", fontWeight: "600", color: "#fff" }}>
+          AI {data.matchText}
+        </div>
+      )}
+      {data.description && <p style={{ color: "#ddd" }}>{data.description}</p>}
+      {data.frameImageUrl && (
+        <div
+          className="live-frame-image-container"
+          style={{
+            overflow: "hidden",
+            aspectRatio: "16/9",
+            maxWidth: "calc(200px * 16 / 9)",
+            width: "fit-content",
+            maxHeight: "200px",
+            objectFit: "cover",
+            borderRadius: "8px",
+          }}
+        >
+          <img
+            src={data.frameImageUrl}
+            alt={`Frame for ${data.name}`}
+            className="live-frame-image"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useCallback, useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server.browser";
 import ChannelLogo from "./ChannelLogo";
+import AiDetails from "./AiDetails";
 
 import LikeButton from "./buttons/LikeButton";
 import DislikeButton from "./buttons/DislikeButton";
@@ -513,6 +514,11 @@ export default function LiveShopping({ channelId, onLike }) {
            (1) SCROLLABLE BELT: only images are visible here
       ───────────────────────────────────────────────────────────────── */}
       <div id="absolute-container" ref={scrollBoxRef}>
+        <div className="ai-details">
+          {allCardData.map((d, i) => (
+            <AiDetails key={i} data={d} />
+          ))}
+        </div>
         <div id="itemContent" ref={beltRef}></div>
         <div className="all-live-details">
           {allCardData.map((d, i) => (

--- a/src/styles/liveShoppingDesktop.css
+++ b/src/styles/liveShoppingDesktop.css
@@ -122,4 +122,8 @@
   .all-live-details {
     flex-direction: column;
   }
+
+  .ai-details {
+    flex-direction: column;
+  }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -474,6 +474,12 @@ section {
   padding: 10px;
 }
 
+.ai-details {
+  display: flex;
+  gap: 20px;
+  padding: 10px;
+}
+
 /* Quick Access Tab */
 .quick-access-list {
   list-style: none;


### PR DESCRIPTION
## Summary
- render AI details in new container inside `LiveShopping`
- style `.ai-details` for mobile and desktop
- support AI details rendering via new `AiDetails` component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68606c3ab33c83238e6f23562a4ebe69