### PR TITLE
Restore focus logic and update frame gallery

### DIFF
--- a/src/components/FrameGallery.jsx
+++ b/src/components/FrameGallery.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useProducts } from "../contexts/ProductsContext";
 
-export default function FrameGallery() {
+export default function FrameGallery({ selectedId }) {
   const { products } = useProducts();
   return (
     <div className="ai-frame-gallery">
@@ -15,7 +15,7 @@ export default function FrameGallery() {
               minHeight: "90px",
             }}
             key={p.id}
-            className="frame-gallery-item"
+            className={`frame-gallery-item${selectedId === p.id ? " focused" : ""}`}
           >
             <img
               style={{
@@ -29,16 +29,25 @@ export default function FrameGallery() {
               src={p.back_image}
               alt={`Frame for ${p.title}`}
             />
-            <p
-              style={{
-                fontSize: "0.8rem",
-                color: "#fff",
-                textAlign: "center",
-                marginTop: "4px",
-              }}
-            >
-              {p.description || "No description available"}
-            </p>
+            {p.matchType && (
+              <p
+                style={{ fontSize: "0.8rem", color: "#fff", marginTop: "4px" }}
+              >
+                AI {p.matchType}
+              </p>
+            )}
+            {p.explanation && (
+              <p
+                style={{
+                  fontSize: "0.8rem",
+                  color: "#fff",
+                  textAlign: "center",
+                  marginTop: "4px",
+                }}
+              >
+                {p.explanation}
+              </p>
+            )}
           </div>
         ) : null
       )}

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,12 +1,10 @@
-import React, { useState } from "react";
+import React from "react";
 import LikeButton from "./buttons/LikeButton";
 import DislikeButton from "./buttons/DislikeButton";
 import ShareButton from "./buttons/ShareButton";
-import SvgFrame from "./svgs/SvgFrame";
 import { FormatPrice } from "../legacy/modules/productsModule";
 
-export default function ProductCard({ product, showDetails = false }) {
-  const [animateFrame, setAnimateFrame] = useState(false);
+export default function ProductCard({ product, showDetails = false, focused = false }) {
   if (!product) return null;
 
   const hidden = showDetails ? {} : { display: "none" };
@@ -25,61 +23,15 @@ export default function ProductCard({ product, showDetails = false }) {
     : product.logo_url || "";
 
   return (
-    <div className={`item-container ${showDetails ? "show-details" : ""}`} data-product-id={product.id}>
+    <div
+      className={`item-container ${showDetails ? "show-details" : ""} ${focused ? "focused" : ""}`}
+      data-product-id={product.id}
+    >
       <div className="live-image-container">
         <img data-role="product-image" src={product.image} alt={product.title} loading="lazy" />
       </div>
       <div className="card-details live-details" style={showDetails ? {} : { display: "none" }}>
         <div data-role="product-name" style={hidden}>{product.title}</div>
-        <div style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "0.95rem", lineHeight: "1.4", color: "#ddd" }}>
-          <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-            {product.matchType && (
-              <span style={{ display: "inline-flex", fontSize: "1rem", fontWeight: "600", color: "#fff", justifyContent: "center", alignItems: "center", gap: "0.25rem" }}>
-                AI <span data-role="matchText" style={hidden}>{product.matchType}</span>
-              </span>
-            )}
-            <button
-              data-role="frame-toggle"
-              onClick={() => setAnimateFrame((p) => !p)}
-              style={{
-                display: "inline-flex",
-                padding: 0,
-                marginLeft: "4px",
-                border: "none",
-                background: "transparent",
-                color: "#4fa",
-                cursor: "pointer",
-                fontSize: "0.9rem",
-              }}
-            >
-              <SvgFrame style={{ marginRight: "4px", flexShrink: 0 }} />
-              <span data-role="toggle-text">{animateFrame ? "Hide Frame" : "Show Frame"}</span>
-            </button>
-          </div>
-          <p data-role="ai-description" className="ai-query" style={{ ...hidden, fontSize: "0.85rem", color: "#ddd", whiteSpace: "normal" }}>
-            {product.explanation}
-          </p>
-        </div>
-        {product.back_image && (
-          <div
-            className="live-frame-image-container"
-            data-role="frame-container"
-            style={{
-              overflow: "hidden",
-              aspectRatio: "16/9",
-              maxWidth: "calc(200px * 16 / 9)",
-              width: "fit-content",
-              maxHeight: animateFrame ? "200px" : "0px",
-              objectFit: "cover",
-              borderRadius: "8px",
-              opacity: animateFrame ? 1 : 0,
-              transform: animateFrame ? "translateY(0)" : "translateY(-20px)",
-              transition: "opacity 0.4s ease, transform 0.4s ease, max-height 0.4s ease",
-            }}
-          >
-            <img className="live-frame-image" data-role="frame-image" src={product.back_image} alt={`Frame for ${product.title}`} />
-          </div>
-        )}
         {price && (
           <p
             data-role="product-price-container"

--- a/src/styles/liveShoppingDesktop.css
+++ b/src/styles/liveShoppingDesktop.css
@@ -138,4 +138,8 @@
     min-height: 110px;
     min-width: 180px;
   }
+
+  .frame-gallery-item.focused {
+    outline: 2px solid var(--color-primary);
+  }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -490,3 +490,7 @@ section {
   min-height: 110px;
   min-height: 110px;
 }
+
+.frame-gallery-item.focused {
+  outline: 2px solid var(--color-primary);
+}


### PR DESCRIPTION
## Summary
- add focus logic back to `LiveShopping` and highlight current frame
- simplify `ProductCard` by removing frame toggle and AI text
- show match text and description in `FrameGallery`
- style focused frame items

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862a60275e88323b05cdd81ec93df73