### PR TITLE
Fix hover focus on desktop

### DIFF
--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -4,7 +4,13 @@ import DislikeButton from "./buttons/DislikeButton";
 import ShareButton from "./buttons/ShareButton";
 import { FormatPrice } from "../legacy/modules/productsModule";
 
-export default function ProductCard({ product, showDetails = false, focused = false, extraClass = "" }) {
+export default function ProductCard({
+  product,
+  showDetails = false,
+  focused = false,
+  extraClass = "",
+  onMouseEnter,
+}) {
   if (!product) return null;
 
   const hidden = showDetails ? {} : { display: "none" };
@@ -26,6 +32,7 @@ export default function ProductCard({ product, showDetails = false, focused = fa
     <div
       className={`item-container ${showDetails ? "show-details" : ""} ${focused ? "focused" : ""} ${extraClass}`}
       data-product-id={product.id}
+      onMouseEnter={onMouseEnter}
     >
       <div className="live-image-container">
         <img data-role="product-image" src={product.image} alt={product.title} loading="lazy" />


### PR DESCRIPTION
## Summary
- add `onMouseEnter` prop to `ProductCard` so hovering focuses the card

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862e57a09408323b9e3d32460a907fb