### PR TITLE
Prepend new products in LiveShopping

### DIFF
--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -62,10 +62,10 @@ export default function LiveShopping({ onLike }) {
       const nextIds = products.map((p) => p.id);
       let updated = [...prev];
 
-      // handle additions
+      // handle additions: put new items at the start so they appear first
       products.forEach((p) => {
         if (!prevIds.includes(p.id)) {
-          updated.push({ ...p, _status: "enter" });
+          updated.unshift({ ...p, _status: "enter" });
           requestAnimationFrame(() => {
             setDisplayProducts((cur) =>
               cur.map((it) => (it.id === p.id ? { ...it, _status: "" } : it))


### PR DESCRIPTION
## Summary
- ensure LiveShopping adds new product cards to the beginning of the list
- clarify comment for item insertion logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863c9ce9c708323ae4dcf683c14b198