### PR TITLE
Prepend products and sync frames

### DIFF
--- a/src/components/FrameGallery.jsx
+++ b/src/components/FrameGallery.jsx
@@ -1,18 +1,19 @@
 import React, { forwardRef } from "react";
 import { useProducts } from "../contexts/ProductsContext";
 
-const FrameGallery = forwardRef(function FrameGallery({ selectedId }, ref) {
+const FrameGallery = forwardRef(function FrameGallery({ selectedId, items }, ref) {
   const { products } = useProducts();
+  const frames = items || products;
   return (
     <div className="ai-frame-gallery" ref={ref}>
-      {products.map((p) =>
+      {frames.map((p) =>
         p.back_image ? (
           <div
             style={{ position: "relative" }}
             key={p.id}
-            className={`frame-gallery-item ${
+            className={`frame-gallery-item${
               selectedId === p.id ? " focused" : ""
-            }`}
+            }${p._status ? ` ${p._status}` : ""}`}
           >
             <img
               style={{

--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -62,10 +62,32 @@ export default function LiveShopping({ onLike }) {
       const nextIds = products.map((p) => p.id);
       let updated = [...prev];
 
-      // handle additions
+      // handle additions: put new items at the start so they appear first
       products.forEach((p) => {
         if (!prevIds.includes(p.id)) {
-          updated.push({ ...p, _status: "enter" });
+          updated.unshift({ ...p, _status: "enter" });
+
+          const container = scrollRef.current;
+          const gallery = galleryRef.current;
+          const first = beltRef.current?.querySelector(".item-container");
+          if (container && gallery && first) {
+            const horiz = container.scrollWidth > container.clientWidth;
+            const delta = horiz ? first.offsetWidth : first.offsetHeight;
+            if (horiz) {
+              container.scrollLeft += delta;
+              const maxC = container.scrollWidth - container.clientWidth;
+              const maxG = gallery.scrollWidth - gallery.clientWidth;
+              const ratio = maxC ? container.scrollLeft / maxC : 0;
+              gallery.scrollLeft = ratio * maxG;
+            } else {
+              container.scrollTop += delta;
+              const maxC = container.scrollHeight - container.clientHeight;
+              const maxG = gallery.scrollHeight - gallery.clientHeight;
+              const ratio = maxC ? container.scrollTop / maxC : 0;
+              gallery.scrollTop = ratio * maxG;
+            }
+          }
+
           requestAnimationFrame(() => {
             setDisplayProducts((cur) =>
               cur.map((it) => (it.id === p.id ? { ...it, _status: "" } : it))
@@ -184,7 +206,11 @@ export default function LiveShopping({ onLike }) {
 
   return (
     <div className="liveshopping-container" style={{ width: "100%" }}>
-      <FrameGallery ref={galleryRef} selectedId={selected?.id} />
+      <FrameGallery
+        ref={galleryRef}
+        selectedId={selected?.id}
+        items={displayProducts}
+      />
       <div id="absolute-container" ref={scrollRef}>
         <div id="itemContent" ref={beltRef} style={{ display: "flex" }}>
           {displayProducts.map((p) => (

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -309,6 +309,7 @@ section {
   width: 0;
   height: 0;
   opacity: 0;
+  transform: scale(0);
 }
 
 .item-container.exit {
@@ -317,6 +318,7 @@ section {
   opacity: 0;
   margin: 0;
   padding: 0;
+  transform: scale(0);
 }
 
 /* ─────── “Focused” card: scale + shadow ─────── */
@@ -526,6 +528,22 @@ section {
   transition: all 0.3s ease;
   margin: 0;
   border-radius: 6px;
+}
+
+.frame-gallery-item.enter {
+  width: 0;
+  height: 0;
+  opacity: 0;
+  transform: scale(0);
+}
+
+.frame-gallery-item.exit {
+  width: 0;
+  height: 0;
+  opacity: 0;
+  margin: 0;
+  padding: 0;
+  transform: scale(0);
 }
 
 .ai-frame-gallery {


### PR DESCRIPTION
## Summary
- keep frame gallery in sync with product list
- adjust scroll when new products prepend
- expose display products to `FrameGallery`
- animate frames and desktop items smoothly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863c9ce9c708323ae4dcf683c14b198