### PR TITLE
Fix mobile frame focus

### DIFF
--- a/src/components/FrameGallery.jsx
+++ b/src/components/FrameGallery.jsx
@@ -12,7 +12,7 @@ const FrameGallery = forwardRef(function FrameGallery({ selectedId, items }, ref
             style={{ position: "relative" }}
             key={p.id}
             className={`frame-gallery-item${
-              selectedId === p.id ? " focused" : ""
+              String(selectedId) === String(p.id) ? " focused" : ""
             }${p._status ? ` ${p._status}` : ""}`}
           >
             <img

--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -16,7 +16,7 @@ export default function LiveShopping() {
   useEffect(() => {
     function handler(e) {
       addProduct(e.detail);
-      setSelectedId((cur) => cur || e.detail.id);
+      setSelectedId((cur) => cur || String(e.detail.id));
     }
     window.addEventListener("new-product", handler);
     return () => window.removeEventListener("new-product", handler);
@@ -60,12 +60,12 @@ export default function LiveShopping() {
 
   useEffect(() => {
     if (!selectedId && products.length) {
-      setSelectedId(products[0].id);
+      setSelectedId(String(products[0].id));
     }
   }, [products, selectedId]);
 
   const handleHover = useCallback((p) => {
-    setSelectedId(p.id);
+    setSelectedId(String(p.id));
   }, []);
 
   useEffect(() => {
@@ -75,8 +75,8 @@ export default function LiveShopping() {
 
     function applyFocus(card) {
       if (!card || card === lastFocusedRef.current) return;
-      const id = Number(card.getAttribute("data-product-id"));
-      if (displayProducts.some((pr) => pr.id === id)) {
+      const id = card.getAttribute("data-product-id");
+      if (displayProducts.some((pr) => String(pr.id) === String(id))) {
         lastFocusedRef.current = card;
         setSelectedId(id);
       }
@@ -180,9 +180,10 @@ export default function LiveShopping() {
               key={p.id}
               product={p}
               showDetails
-              focused={selectedId === p.id}
+              focused={String(selectedId) === String(p.id)}
               extraClass={p._status}
               onMouseEnter={() => handleHover(p)}
+              onClick={() => handleHover(p)}
             />
           ))}
         </div>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -10,6 +10,7 @@ export default function ProductCard({
   focused = false,
   extraClass = "",
   onMouseEnter,
+  onClick,
 }) {
   if (!product) return null;
 
@@ -33,6 +34,8 @@ export default function ProductCard({
       className={`item-container ${showDetails ? "show-details" : ""} ${focused ? "focused" : ""} ${extraClass}`}
       data-product-id={product.id}
       onMouseEnter={onMouseEnter}
+      onClick={onClick}
+      onTouchStart={onClick}
     >
       <div className="live-image-container">
         <img data-role="product-image" src={product.image} alt={product.title} loading="lazy" />


### PR DESCRIPTION
## Summary
- treat product IDs as strings when tracking focus
- update equality checks in LiveShopping and FrameGallery

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68642d524b3483238e330adb24d28f8d