### PR TITLE
Disable click for product focus

### DIFF
--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -183,7 +183,6 @@ export default function LiveShopping() {
               focused={String(selectedId) === String(p.id)}
               extraClass={p._status}
               onMouseEnter={() => handleHover(p)}
-              onClick={() => handleHover(p)}
             />
           ))}
         </div>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -10,7 +10,6 @@ export default function ProductCard({
   focused = false,
   extraClass = "",
   onMouseEnter,
-  onClick,
 }) {
   if (!product) return null;
 
@@ -34,8 +33,6 @@ export default function ProductCard({
       className={`item-container ${showDetails ? "show-details" : ""} ${focused ? "focused" : ""} ${extraClass}`}
       data-product-id={product.id}
       onMouseEnter={onMouseEnter}
-      onClick={onClick}
-      onTouchStart={onClick}
     >
       <div className="live-image-container">
         <img data-role="product-image" src={product.image} alt={product.title} loading="lazy" />


### PR DESCRIPTION
## Summary
- stop ProductCard from receiving click handler
- remove click-based focus handling in LiveShopping

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68643086659483238cf9a0295805d97e