### PR TITLE
Fix product transition classes

### DIFF
--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -36,11 +36,11 @@ export default function LiveShopping() {
         if (!prevIds.includes(p.id)) {
           updated.unshift({ ...p, _status: "enter" });
 
-          requestAnimationFrame(() => {
+          setTimeout(() => {
             setDisplayProducts((cur) =>
               cur.map((it) => (it.id === p.id ? { ...it, _status: "" } : it))
             );
-          });
+          }, 50);
         }
       });
 


### PR DESCRIPTION
## Summary
- ensure newly added products keep `.enter` class long enough to animate

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686435698ab8832399290206fcf09b09