### PR TITLE
Fix product transitions

### DIFF
--- a/src/components/LiveShopping.jsx
+++ b/src/components/LiveShopping.jsx
@@ -8,18 +8,34 @@ import useIsMobile from "../hooks/useIsMobile";
 export default function LiveShopping() {
   const { products, addProduct } = useProducts();
   const [selectedId, setSelectedId] = useState(null);
-  const [displayProducts, setDisplayProducts] = useState([]);
+  const [displayProducts, setDisplayProducts] = useState(() => products);
   const isMobile = useIsMobile();
   const scrollRef = useRef(null);
   const galleryRef = useRef(null);
   const beltRef = useRef(null);
   const lastFocusedRef = useRef(null);
 
+
   useEffect(() => {
     function handler(e) {
-      addProduct(e.detail);
-      setSelectedId((cur) => cur || String(e.detail.id));
+      const p = e.detail;
+      addProduct(p);
+      setSelectedId((cur) => cur || String(p.id));
+
+      setDisplayProducts((prev) => {
+        if (prev.some((it) => it.id === p.id)) return prev;
+        const updated = [{ ...p, _status: "enter" }, ...prev];
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            setDisplayProducts((cur) =>
+              cur.map((it) => (it.id === p.id ? { ...it, _status: "" } : it))
+            );
+          });
+        });
+        return updated;
+      });
     }
+
     window.addEventListener("new-product", handler);
     return () => window.removeEventListener("new-product", handler);
   }, [addProduct]);
@@ -27,22 +43,8 @@ export default function LiveShopping() {
   // sync products with animated display list
   useEffect(() => {
     setDisplayProducts((prev) => {
-      const prevIds = prev.map((p) => p.id);
       const nextIds = products.map((p) => p.id);
       let updated = [...prev];
-
-      // handle additions: put new items at the start so they appear first
-      products.forEach((p) => {
-        if (!prevIds.includes(p.id)) {
-          updated.unshift({ ...p, _status: "enter" });
-
-          requestAnimationFrame(() => {
-            setDisplayProducts((cur) =>
-              cur.map((it) => (it.id === p.id ? { ...it, _status: "" } : it))
-            );
-          });
-        }
-      });
 
       // handle removals
       prev.forEach((p) => {
@@ -50,9 +52,13 @@ export default function LiveShopping() {
           updated = updated.map((it) =>
             it.id === p.id ? { ...it, _status: "exit" } : it
           );
-          setTimeout(() => {
-            setDisplayProducts((cur) => cur.filter((it) => it.id !== p.id));
-          }, 500);
+
+          // wait for exit transition before removing the item
+          requestAnimationFrame(() => {
+            setTimeout(() => {
+              setDisplayProducts((cur) => cur.filter((it) => it.id !== p.id));
+            }, 500);
+          });
         }
       });
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -310,6 +310,7 @@ section {
   height: 0;
   opacity: 0;
   overflow: hidden;
+  transform: scale(0);
 }
 
 .item-container.exit {
@@ -318,6 +319,7 @@ section {
   opacity: 0;
   margin: 0;
   padding: 0;
+  transform: scale(0);
 }
 
 /* ─────── “Focused” card: scale + shadow ─────── */


### PR DESCRIPTION
## Summary
- manage product additions inside LiveShopping instead of syncing on every context update
- remove `.enter` toggling from the products effect so it only handles removals

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686435698ab8832399290206fcf09b09