### PR TITLE
Add stream URLs for demo channels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ const InTravelLivestorePage = lazy(() =>
 const PrivacyPage = lazy(() => import("./pages/PrivacyPage"));
 const TermsPage = lazy(() => import("./pages/TermsPage"));
 const HomePage = lazy(() => import("./pages/HomePage"));
+const DemoPage = lazy(() => import("./pages/DemoPage"));
 import BuildInfo from "./components/BuildInfo";
 
 // OAuth callback
@@ -49,6 +50,7 @@ export default function App() {
           <Route path="/privacy-policy" element={<PrivacyPage />} />
           <Route path="/terms-and-services" element={<TermsPage />} />
           <Route path="/home" element={<HomePage />} />
+          <Route path="/demo" element={<DemoPage />} />
 
           {/* 4) Fallback */}
           <Route path="*" element={<Navigate to="/home" replace />} />

--- a/src/components/QuickAccessTab.jsx
+++ b/src/components/QuickAccessTab.jsx
@@ -1,22 +1,5 @@
 import React from "react";
-
-const channels = [
-  { name: "ATP Media", id: "2d192295-4e70-4187-a06d-55ecac2f9bf6" },
-  { name: "CW Networks", id: "946027d4-367c-4f7d-90e4-4929638d60bc" },
-  { name: "Danger TV", id: "a1ba66f8-4540-444d-be98-bc5f761169c0" },
-  { name: "EuroNews", id: "4deb3daf-a58c-4da5-aabc-e84f00eb50da" },
-  { name: "EuroNews Travel", id: "bf08f473-7888-4fbb-a97e-d862f484a1c8" },
-  { name: "Insight TV (EU)", id: "3af7a440-2c68-45bc-ab31-9384fc4c4bcb" },
-  { name: "Insight TV (UK)", id: "ada3896d-0456-4589-95fa-cf71718b79c8" },
-  { name: "Insight TV (US)", id: "3d8c4c38-2d6e-483c-bdc5-e1eeeadd155e" },
-  { name: "MVMNT Culture", id: "ba08370c-0362-462d-b299-97cc36973340" },
-  {
-    name: "Narative Entertainment",
-    id: "ba398d25-ef88-4762-bcd6-d75a2930fbeb",
-  },
-  { name: "Wedosport", id: "2de0e45d-1eda-4f15-a4d8-0076485b9545" },
-  { name: "WILD TV", id: "43b08654-edb3-4757-9a53-4249b3f6ddfd" },
-];
+import { channels } from "../data/channels";
 
 export default function QuickAccessTab() {
   const origin = window.location.origin;

--- a/src/data/channels.js
+++ b/src/data/channels.js
@@ -1,0 +1,66 @@
+const DEFAULT_STREAM_URL =
+  "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8";
+
+export const channels = [
+  {
+    name: "ATP Media",
+    id: "2d192295-4e70-4187-a06d-55ecac2f9bf6",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "CW Networks",
+    id: "946027d4-367c-4f7d-90e4-4929638d60bc",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "Danger TV",
+    id: "a1ba66f8-4540-444d-be98-bc5f761169c0",
+    streamUrl: "https://dangertv-us.xumo.wurl.tv/playlist.m3u8",
+  },
+  {
+    name: "EuroNews",
+    id: "4deb3daf-a58c-4da5-aabc-e84f00eb50da",
+    streamUrl: "https://a-cdn.klowdtv.com/live3/euronews_720p/playlist.m3u8",
+  },
+  {
+    name: "EuroNews Travel",
+    id: "bf08f473-7888-4fbb-a97e-d862f484a1c8",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "Insight TV (EU)",
+    id: "3af7a440-2c68-45bc-ab31-9384fc4c4bcb",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "Insight TV (UK)",
+    id: "ada3896d-0456-4589-95fa-cf71718b79c8",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "Insight TV (US)",
+    id: "3d8c4c38-2d6e-483c-bdc5-e1eeeadd155e",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "MVMNT Culture",
+    id: "ba08370c-0362-462d-b299-97cc36973340",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "Narative Entertainment",
+    id: "ba398d25-ef88-4762-bcd6-d75a2930fbeb",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "Wedosport",
+    id: "2de0e45d-1eda-4f15-a4d8-0076485b9545",
+    streamUrl: DEFAULT_STREAM_URL,
+  },
+  {
+    name: "WILD TV",
+    id: "43b08654-edb3-4757-9a53-4249b3f6ddfd",
+    streamUrl:
+      "https://dfhsahpa45kk2.cloudfront.net/scheduler/scheduleMaster/476.m3u8",
+  },
+];

--- a/src/pages/DemoPage.jsx
+++ b/src/pages/DemoPage.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { channels } from "../data/channels";
+import ChannelLogo from "../components/ChannelLogo";
+
+export default function DemoPage() {
+  const [searchParams] = useSearchParams();
+  const [channel, setChannel] = useState(null);
+
+  useEffect(() => {
+    const name = searchParams.get("channelName");
+    if (!name) return;
+    const match = channels.find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    if (match) {
+      setChannel(match);
+      window.channelId = match.id;
+      try {
+        localStorage.setItem("channelId", match.id);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [searchParams]);
+
+  if (!channel) {
+    return <div className="demo-page" style={{ padding: "1rem" }}>Channel not found.</div>;
+  }
+
+  return (
+    <div className="demo-page" style={{ padding: "1rem" }}>
+      <div style={{ marginBottom: "1rem" }}>
+        <ChannelLogo channelId={channel.id} />
+      </div>
+      <video controls autoPlay style={{ width: "100%", maxWidth: "640px" }}>
+        <source src={channel.streamUrl} type="application/x-mpegURL" />
+        Your browser does not support the video tag.
+      </video>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- include stream URLs in `src/data/channels.js`
- update `DemoPage` to use the channel's stream URL

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f90e031d083239f4ebf5ff2b1889b