### PR TITLE
Update channel HLS links and fix OAuth overlay

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'edgevideo-ai-8753a_6bbbbc7bd2acd0dd'] },
   {
     files: ['**/*.{js,jsx}'],
     languageOptions: {

--- a/src/auth/OAuthCallback.jsx
+++ b/src/auth/OAuthCallback.jsx
@@ -28,8 +28,8 @@ export default function OAuthCallback() {
   }, [fetchUser, navigate]);
 
   return (
-    <p style={{ padding: 20, color: "#fff" }}>
+    <div style={{ padding: 20, color: "#fff" }}>
       <LoadingOverlay message="Signing In..." />
-    </p>
+    </div>
   );
 }

--- a/src/data/channels.js
+++ b/src/data/channels.js
@@ -14,7 +14,7 @@ export const channels = [
   {
     name: "Danger TV",
     id: "a1ba66f8-4540-444d-be98-bc5f761169c0",
-    streamUrl: "https://dangertv-us.xumo.wurl.tv/playlist.m3u8",
+    streamUrl: "https://dangertv-us.ono.wurl.tv/playlist.m3u8",
   },
   {
     name: "EuroNews",
@@ -29,7 +29,8 @@ export const channels = [
   {
     name: "Insight TV (EU)",
     id: "3af7a440-2c68-45bc-ab31-9384fc4c4bcb",
-    streamUrl: DEFAULT_STREAM_URL,
+    streamUrl:
+      "https://amg00861-amg00861c22-nbt-us-7736.playouts.now.amagi.tv/playlist.m3u8",
   },
   {
     name: "Insight TV (UK)",
@@ -44,22 +45,25 @@ export const channels = [
   {
     name: "MVMNT Culture",
     id: "ba08370c-0362-462d-b299-97cc36973340",
-    streamUrl: DEFAULT_STREAM_URL,
+    streamUrl:
+      "https://d15g7z5n3epv7t.cloudfront.net/v1/master/9d062541f2ff39b5c0f48b743c6411d25f62fc25/TheGrapplingNetwork-EdgeVideo/443.m3u8",
   },
   {
     name: "Narative Entertainment",
     id: "ba398d25-ef88-4762-bcd6-d75a2930fbeb",
-    streamUrl: DEFAULT_STREAM_URL,
+    streamUrl:
+      "https://amg01753-amg01753c2-amagitv-us-7963.playouts.now.amagi.tv/playlist.m3u8",
   },
   {
     name: "Wedosport",
     id: "2de0e45d-1eda-4f15-a4d8-0076485b9545",
-    streamUrl: DEFAULT_STREAM_URL,
+    streamUrl:
+      "https://cdn-uw2-prod.tsv2.amagi.tv/linear/amg00735-videosolutionsa-wedosports-ono/playlist.m3u8?app_bundle=REPLACE_ME&app_name=REPLACE_ME&app_store_url=REPLACE_ME&url=REPLACE_ME&genre=REPLACE_ME&ic=REPLACE_ME&us_privacy=REPLACE_ME&gdpr=REPLACE_ME&gdpr_consent=REPLACE_ME&did=REPLACE_ME&dnt=REPLACE_ME&coppa=REPLACE_ME",
   },
   {
     name: "WILD TV",
     id: "43b08654-edb3-4757-9a53-4249b3f6ddfd",
     streamUrl:
-      "https://dfhsahpa45kk2.cloudfront.net/scheduler/scheduleMaster/476.m3u8",
+      "https://d26832vdq1ny9k.cloudfront.net/v1/master/9d062541f2ff39b5c0f48b743c6411d25f62fc25/Test-MuxIP-WildTV/476.m3u8",
   },
 ];


### PR DESCRIPTION
## Summary
- update Danger TV and other HLS URLs in channel data
- ignore build artifact folder in ESLint config
- fix OAuthCallback markup to avoid invalid div nesting
- run lint and build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68702e604a408323b5e8d258df7a394c