### PR TITLE
Add channel selection to demo page

### DIFF
--- a/src/pages/DemoPage.jsx
+++ b/src/pages/DemoPage.jsx
@@ -8,6 +8,7 @@ import Hls from "hls.js";
 export default function DemoPage() {
   const [searchParams] = useSearchParams();
   const [channel, setChannel] = useState(null);
+  const origin = window.location.origin;
 
   const videoRef = useRef(null);
   useEffect(() => {
@@ -40,22 +41,38 @@ export default function DemoPage() {
       return () => hls.destroy();
     }
   }, [channel]);
-  if (!channel) {
-    return (
-      <div className="demo-page" style={{ padding: "1rem" }}>
-        Channel not found.
-      </div>
-    );
-  }
-
   return (
     <div className="demo-page">
-      <div className="channel-logo">
-        <ChannelLogo channelId={channel.id} />
+      <div className="demo-links">
+        <ul className="quick-access-list">
+          {channels.map((c) => (
+            <li key={c.id}>
+              <button
+                className="btn btn--primary quick-access-btn"
+                onClick={() => {
+                  window.location.href = `${origin}/demo?channelName=${encodeURIComponent(
+                    c.name
+                  )}`;
+                }}
+              >
+                {c.name}
+              </button>
+            </li>
+          ))}
+        </ul>
       </div>
-      <video ref={videoRef} controls autoPlay muted>
-        Your browser does not support the video tag.
-      </video>
+      {channel ? (
+        <>
+          <div className="channel-logo">
+            <ChannelLogo channelId={channel.id} />
+          </div>
+          <video ref={videoRef} controls autoPlay muted>
+            Your browser does not support the video tag.
+          </video>
+        </>
+      ) : (
+        <p style={{ padding: "1rem" }}>Channel not found.</p>
+      )}
     </div>
   );
 }

--- a/src/styles/demoPage.css
+++ b/src/styles/demoPage.css
@@ -51,3 +51,35 @@ video {
   transform: scale(1.05);
   transition: transform 0.2s ease-in-out;
 }
+
+.demo-links {
+  margin-bottom: 1rem;
+  width: 100%;
+}
+
+.quick-access-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #617afa;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.btn:hover {
+  opacity: 0.9;
+}
+
+.quick-access-btn {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
- add button list on DemoPage to quickly open each channel
- style buttons in `demoPage.css`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870473b4b0083238268983e6bc44b58