### PR TITLE
Remove unused detail classes

### DIFF
--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -31,9 +31,7 @@ export default function ProductCard({
 
   return (
     <div
-      className={`item-container ${showDetails ? "show-details" : ""} ${
-        focused ? "focused" : ""
-      } ${extraClass}`}
+      className={`item-container ${focused ? "focused" : ""} ${extraClass}`}
       data-product-id={product.id}
       onMouseEnter={onMouseEnter}
     >
@@ -63,7 +61,7 @@ export default function ProductCard({
         )}
       </div>
       <div
-        className="card-details live-details"
+        className="card-details"
         style={showDetails ? {} : { display: "none" }}
       >
         <div data-role="product-name" style={hidden}>

--- a/src/styles/liveShoppingDesktop.css
+++ b/src/styles/liveShoppingDesktop.css
@@ -35,11 +35,7 @@
     fill: white;
   }
 
-  /* Product card details displayed on hover devices */
 
-  .item-container.show-details .card-details {
-    display: flex;
-  }
 
   .item-container {
     width: 100%;
@@ -114,7 +110,7 @@
     transform: scale(1.05);
   }
 
-  .live-details {
+  .card-details {
     justify-content: center;
     max-height: none;
     width: 400px;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -456,18 +456,6 @@ section {
   stroke: var(--color-black);
 }
 
-.live-details {
-  border-radius: 8px;
-  color: rgb(255, 255, 255);
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: stretch;
-  padding: 10px 20px 0;
-  gap: 10px;
-}
-
 .socials-ul {
   display: flex;
   justify-content: space-between;
@@ -488,10 +476,12 @@ section {
 .card-details {
   border-radius: 8px;
   color: #fff;
+  flex: 1;
+  display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: stretch;
-  padding: 10px;
+  padding: 10px 20px 0;
   gap: 10px;
 }
 


### PR DESCRIPTION
## Summary
- trim CSS by merging `.live-details` into `.card-details`
- drop `show-details` class usage in `ProductCard`

## Testing
- `npm run lint` *(fails: no-unused-vars in unrelated files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f708a30548323ad674fd2dccb5123