### PR TITLE
Fix demo product download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "edgevideo-app",
       "version": "0.0.6",
       "dependencies": {
+        "file-saver": "^2.0.5",
         "hls.js": "^1.6.7",
+        "jszip": "^3.10.1",
         "lint": "^0.8.19",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2293,6 +2295,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2535,6 +2543,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2721,6 +2735,12 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2831,6 +2851,18 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2853,6 +2885,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lint": {
@@ -3405,6 +3446,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3523,6 +3570,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -3669,6 +3722,27 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/replace-in-file": {
       "version": "3.4.4",
@@ -3940,6 +4014,12 @@
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4024,6 +4104,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "2.1.1",
@@ -4221,6 +4316,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "file-saver": "^2.0.5",
     "hls.js": "^1.6.7",
+    "jszip": "^3.10.1",
     "lint": "^0.8.19",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/DemoProductWidget.jsx
+++ b/src/components/DemoProductWidget.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import "../styles/demoProductWidget.css";
+import { downloadProduct } from "../utils/downloadProduct";
 
 export default function DemoProductWidget({ onClose, channelName }) {
   const [liveProducts, setLiveProducts] = useState([]);
@@ -15,8 +16,8 @@ export default function DemoProductWidget({ onClose, channelName }) {
         // Check if product already exists
         if (prev.some((p) => p.id === product.id)) return prev;
 
-        // Add new product to the beginning, keep max 3 products
-        const updated = [product, ...prev].slice(0, 3);
+        // Add new product to the beginning, keep max 10 products
+        const updated = [product, ...prev].slice(0, 10);
         return updated;
       });
 
@@ -40,11 +41,8 @@ export default function DemoProductWidget({ onClose, channelName }) {
     };
   }, [isVisible]);
 
-  const handleDownload = (product) => {
-    // Simulate download functionality
-    alert(
-      `Downloading product data for "${product.title}"\n\nThis would download product images and data as a ZIP file.`
-    );
+  const handleDownload = async (product) => {
+    await downloadProduct(product);
   };
 
   const handleClose = () => {

--- a/src/pages/DemoPage.jsx
+++ b/src/pages/DemoPage.jsx
@@ -4,6 +4,7 @@ import { channels } from "../data/channels";
 import ChannelLogo from "../components/ChannelLogo";
 import { initProductsFeature } from "../legacy/screen";
 import "../styles/demoPage.css";
+import { downloadProduct } from "../utils/downloadProduct";
 import Hls from "hls.js";
 import edgevideoIcon from "/assets/logo.png"; // Adjust path as needed
 import "../styles/reset.css"; // Ensure reset styles are applied
@@ -69,11 +70,8 @@ export default function DemoPage() {
   };
 
   // Product widget functionality
-  const handleDownload = (product) => {
-    // Simulate download functionality
-    alert(
-      `Downloading product data for "${product.title}"\n\nThis would download product images and data as a ZIP file.`
-    );
+  const handleDownload = async (product) => {
+    await downloadProduct(product);
   };
 
   // Listen for new products from the productsModule
@@ -86,8 +84,8 @@ export default function DemoPage() {
         // Check if product already exists
         if (prev.some((p) => p.id === product.id)) return prev;
 
-        // Add new product to the beginning, keep max 3 products
-        const updated = [product, ...prev].slice(0, 3);
+        // Add new product to the beginning, keep max 10 products
+        const updated = [product, ...prev].slice(0, 10);
         return updated;
       });
 

--- a/src/styles/demoPage.css
+++ b/src/styles/demoPage.css
@@ -524,8 +524,8 @@
 }
 
 .products-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 1.5rem;
   max-height: 80vh;
   overflow-y: auto;

--- a/src/utils/downloadProduct.js
+++ b/src/utils/downloadProduct.js
@@ -1,0 +1,45 @@
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+
+function getFileExtension(url) {
+  try {
+    const path = new URL(url).pathname;
+    const ext = path.substring(path.lastIndexOf("."));
+    return ext || "";
+  } catch {
+    return "";
+  }
+}
+
+async function addImageToZip(zip, url, name) {
+  try {
+    const res = await fetch(url);
+    const blob = await res.blob();
+    const ext = getFileExtension(url);
+    zip.file(`${name}${ext}`, blob);
+  } catch (e) {
+    console.warn("Failed to fetch image", url, e);
+  }
+}
+
+export async function downloadProduct(product) {
+  const zip = new JSZip();
+  const info = {
+    id: product.id,
+    title: product.title || product.name || "",
+    price: product.price || "",
+    link: product.link || "",
+  };
+  zip.file("product.json", JSON.stringify(info, null, 2));
+
+  if (product.image) {
+    await addImageToZip(zip, product.image, "image");
+  }
+  const frameUrl = product.frame_url || product.back_image;
+  if (frameUrl) {
+    await addImageToZip(zip, frameUrl, "frame");
+  }
+
+  const blob = await zip.generateAsync({ type: "blob" });
+  saveAs(blob, `product-${product.id || Date.now()}.zip`);
+}


### PR DESCRIPTION
## Summary
- show more products in demo widget and page
- enable product image download to ZIP
- present products in a responsive grid layout
- include JSZip and FileSaver dependencies

## Testing
- `npm run lint` *(fails: no-unused-vars and other errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f97561f8c832396edaf6425742be9